### PR TITLE
Separate launch() and launchZen(), BaseZen now *exposes* a Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,21 @@ $launcher->launch($dialog)->then(
 });
 ```
 
-The launched zenity process exposes methods to control the process while waiting for the results.
+#### launchZen()
+
+The `launchZen($dialog)` method can be used to asynchronously launch a given dialog
+and return an instance of the `BaseZen` class.
+This instance exposes methods to control the zenity process while waiting for the results.
 Some dialog types also support modifying the information presented to the user.
 
 ```php
-$zen = $launcher->launch($dialog);
+$zen = $launcher->launchZen($dialog);
 $loop->addTimer(3.0, function () use ($zen) {
     $zen->close();
+});
+
+$zen->promise()->then(function ($result) {
+    // dialog completed
 });
 ```
 

--- a/examples/blocking.php
+++ b/examples/blocking.php
@@ -17,7 +17,7 @@ if ($name === false) {
     exit;
 }
 
-$pulser = $launcher->launch($builder->pulsate('Searching packagist.org for "' . $name . '"...'));
+$pulser = $launcher->launchZen($builder->pulsate('Searching packagist.org for "' . $name . '"...'));
 sleep(3);
 $pulser->close();
 

--- a/examples/menu.php
+++ b/examples/menu.php
@@ -17,7 +17,7 @@ $main = function() use (&$main, $builder, $launcher) {
     $menu->setWindowIcon('info');
     $menu->setTitle('Main menu');
 
-   $launcher->launch($menu)->then(function ($selected) use ($builder, $main, $launcher) {
+    $launcher->launch($menu)->then(function ($selected) use ($builder, $main, $launcher) {
         if ($selected === '0') {
             // U+2212 MINUS SIGN for alignment
             $launcher->launch($builder->listRadio(array('+2', '+1', '±0', '−1', '−2'), 'Introduction Level', 2))->then(function ($level) use ($main, $launcher) {

--- a/examples/notification.php
+++ b/examples/notification.php
@@ -12,7 +12,7 @@ $launcher = new Launcher($loop);
 $builder = new Builder();
 
 $notification = $builder->notifier();
-$zen = $launcher->launch($notification);
+$zen = $launcher->launchZen($notification);
 
 $zen->setMessage('Hello world');
 
@@ -20,6 +20,5 @@ $n = 0;
 $loop->addPeriodicTimer(10.0, function ($timer) use ($zen, &$n) {
     $notification->setMessage('Hi' . ++$n);
 });
-
 
 $loop->run();

--- a/examples/progress-pulsate.php
+++ b/examples/progress-pulsate.php
@@ -11,7 +11,7 @@ $loop = Factory::create();
 $launcher = new Launcher($loop);
 $builder = new Builder();
 
-$progress = $launcher->launch($builder->pulsate('Pseudo-processing...'));
+$progress = $launcher->launchZen($builder->pulsate('Pseudo-processing...'));
 
 $texts = array(
     'Preparing',
@@ -37,13 +37,13 @@ $timer = $loop->addPeriodicTimer(2.0, function ($timer) use ($progress, $texts) 
     }
 });
 
-$progress->then(function () use ($timer, $builder, $launcher) {
+$progress->promise()->then(function () use ($timer, $builder, $launcher) {
     $timer->cancel();
 
     $launcher->launch($builder->info('Done'));
 });
 
-$progress->then(null, function() use ($timer, $builder, $launcher) {
+$progress->promise()->then(null, function() use ($timer, $builder, $launcher) {
     $timer->cancel();
 
     $launcher->launch($builder->error('Canceled'));

--- a/examples/progress-random.php
+++ b/examples/progress-random.php
@@ -11,7 +11,7 @@ $loop = Factory::create();
 $launcher = new Launcher($loop);
 $builder = new Builder();
 
-$progress = $launcher->launch($builder->progress('Pseudo-processing...'));
+$progress = $launcher->launchZen($builder->progress('Pseudo-processing...'));
 
 $progress->setPercentage(50);
 
@@ -19,14 +19,15 @@ $timer = $loop->addPeriodicTimer(0.2, function () use ($progress) {
     $progress->advance(mt_rand(-1, 3));
 });
 
-$progress->then(function () use ($timer, $builder, $launcher) {
-    $timer->cancel();
+$progress->promise()->then(
+    function () use ($timer, $builder, $launcher) {
+        $timer->cancel();
 
-    $launcher->launch($builder->info('Done'));
-});
-
-$progress->then(null, function() use ($timer) {
-    $timer->cancel();
-});
+        $launcher->launch($builder->info('Done'));
+    },
+    function() use ($timer) {
+        $timer->cancel();
+    }
+);
 
 $loop->run();

--- a/examples/progress.php
+++ b/examples/progress.php
@@ -12,7 +12,7 @@ $loop = Factory::create();
 $launcher = new Launcher($loop);
 $builder = new Builder();
 
-$progress = $launcher->launch($builder->progress('Pseudo-processing...'));
+$progress = $launcher->launchZen($builder->progress('Pseudo-processing...'));
 
 $loop->addPeriodicTimer(0.1, function ($timer) use ($progress) {
     $progress->advance(mt_rand(0, 3));
@@ -22,7 +22,7 @@ $loop->addPeriodicTimer(0.1, function ($timer) use ($progress) {
     }
 });
 
-$pulsate = $launcher->launch($builder->pulsate('[1/3] Preparing...'));
+$pulsate = $launcher->launchZen($builder->pulsate('[1/3] Preparing...'));
 
 $loop->addTimer(2, function() use ($pulsate) {
     $pulsate->setText('[2/3] Downloading...');

--- a/src/Launcher.php
+++ b/src/Launcher.php
@@ -37,7 +37,7 @@ class Launcher
         return $this;
     }
 
-    public function launch(AbstractDialog $dialog)
+    public function launchZen(AbstractDialog $dialog)
     {
         $process = $this->createProcess($dialog);
 
@@ -50,6 +50,11 @@ class Launcher
         $zen->go($process);
 
         return $zen;
+    }
+
+    public function launch(AbstractDialog $dialog)
+    {
+        return $this->launchZen($dialog)->promise();
     }
 
     /**

--- a/src/Zen/BaseZen.php
+++ b/src/Zen/BaseZen.php
@@ -2,11 +2,11 @@
 
 namespace Clue\React\Zenity\Zen;
 
-use React\Promise\PromiseInterface;
+use React\Promise\PromisorInterface;
 use React\ChildProcess\Process;
 use React\Promise\Deferred;
 
-class BaseZen implements PromiseInterface
+class BaseZen implements PromisorInterface
 {
     protected $promise;
     protected $deferred;
@@ -44,9 +44,9 @@ class BaseZen implements PromiseInterface
         });
     }
 
-    public function then($fulfilledHandler = null, $errorHandler = null, $progressHandler = null)
+    public function promise()
     {
-        return $this->promise->then($fulfilledHandler, $errorHandler, $progressHandler);
+        return $this->promise;
     }
 
     public function close()

--- a/tests/FunctionalLauncherTest.php
+++ b/tests/FunctionalLauncherTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Clue\React\Zenity\Launcher;
+use React\EventLoop\Factory;
+use Clue\React\Zenity\Zen\BaseZen;
+
+class LauncherTest extends TestCase
+{
+    private $loop;
+    private $dialog;
+    private $launcher;
+
+    public function setUp()
+    {
+        $this->loop = Factory::create();
+
+        $this->dialog = $this->getMock('Clue\React\Zenity\Dialog\AbstractDialog');
+        $this->dialog->expects($this->once())->method('createZen')->will($this->returnValue(new BaseZen()));
+
+        $this->launcher = new Launcher($this->loop);
+    }
+
+    public function testEchoParameters()
+    {
+        $this->launcher->setBin('echo');
+        $this->dialog->expects($this->once())->method('getArgs')->will($this->returnValue(array('--hello', '--world')));
+
+        $promise = $this->launcher->launch($this->dialog);
+
+        $this->loop->run();
+
+        $promise->then($this->expectCallableOnceWith('--hello --world'));
+    }
+
+    public function testDoesPassStdin()
+    {
+        $this->launcher->setBin('cat');
+        $this->dialog->expects($this->once())->method('getArgs')->will($this->returnValue(array()));
+        $this->dialog->expects($this->once())->method('getInBuffer')->will($this->returnValue('okay'));
+
+        $zen = $this->launcher->launchZen($this->dialog);
+
+        $this->loop->addTimer(0.1, function () use ($zen) {
+            $zen->close();
+        });
+
+        $this->loop->run();
+
+        $zen->promise()->then($this->expectCallableOnceWith('okay'));
+    }
+
+    public function testWaitForOutput()
+    {
+        $this->launcher->setBin('echo');
+        $this->dialog->expects($this->once())->method('getArgs')->will($this->returnValue(array('test')));
+
+        $result = $this->launcher->waitFor($this->dialog);
+
+        $this->assertEquals('test', $result);
+    }
+
+    public function testWaitForError()
+    {
+        $this->launcher->setBin('false');
+        $this->dialog->expects($this->once())->method('getArgs')->will($this->returnValue(array()));
+
+        $result = $this->launcher->waitFor($this->dialog);
+
+        $this->assertEquals(false, $result);
+    }
+}

--- a/tests/Zen/FunctionalBaseZenTest.php
+++ b/tests/Zen/FunctionalBaseZenTest.php
@@ -20,7 +20,7 @@ class FunctionalBaseZenTest extends TestCase
 
         $this->loop->run();
 
-        $zen->then($this->expectCallableOnceWith('okay'));
+        $zen->promise()->then($this->expectCallableOnceWith('okay'));
     }
 
     public function testZenResolvesWithTrueWhenProcessHasNoOutput()
@@ -33,7 +33,7 @@ class FunctionalBaseZenTest extends TestCase
 
         $this->loop->run();
 
-        $zen->then($this->expectCallableOnceWith(true));
+        $zen->promise()->then($this->expectCallableOnceWith(true));
     }
 
     public function testZenRejectsWhenProcessReturnsError()
@@ -46,7 +46,7 @@ class FunctionalBaseZenTest extends TestCase
 
         $this->loop->run();
 
-        $zen->then(null, $this->expectCallableOnceWith(1));
+        $zen->promise()->then(null, $this->expectCallableOnceWith(1));
     }
 
     public function testClosingZenResolvesWithOutputSoFar()
@@ -63,7 +63,7 @@ class FunctionalBaseZenTest extends TestCase
 
         $this->loop->run();
 
-        $zen->then($this->expectCallableOnceWith('okay'));
+        $zen->promise()->then($this->expectCallableOnceWith('okay'));
     }
 
     public function testTerminatingProcessReturnsError()
@@ -80,6 +80,6 @@ class FunctionalBaseZenTest extends TestCase
 
         $this->loop->run();
 
-        $zen->then(null, $this->expectCallableOnce());
+        $zen->promise()->then(null, $this->expectCallableOnce());
     }
 }


### PR DESCRIPTION
* Separate `launch()` and `launchZen()`
* `BaseZen` now *exposes* a `Promise` instead of *being* a `Promise`.
* This achieves a better separation of concerns.
* Also, this means we no longer rely on the `PromiseInterface` (which includes breaking changes between v1 and v2), so this now works with the new Promise API. (refs #4)