### PR TITLE
Explicitly close all STDIO streams when terminating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "react/event-loop": "~0.4.0|~0.3.0",
         "react/child-process": "~0.4.0|~0.3.0"
     },
+    "require-dev": {
+        "clue/block-react": "^1.1"
+    },
     "autoload": {
         "psr-4": { "Clue\\React\\Zenity\\": "src/" }
     }

--- a/src/Zen/BaseZen.php
+++ b/src/Zen/BaseZen.php
@@ -51,10 +51,16 @@ class BaseZen implements PromisorInterface
 
     public function close()
     {
+        // resolve with whatever is currently buffered
         $this->deferred->resolve();
 
         if ($this->process !== null && $this->process->isRunning()) {
             $this->process->terminate(SIGKILL);
+
+            // explicitly close all streams immediately
+            $this->process->stdin->close();
+            $this->process->stdout->close();
+            $this->process->stderr->close();
         }
 
         return $this;

--- a/tests/FunctionalLauncherTest.php
+++ b/tests/FunctionalLauncherTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use Clue\React\Block;
 use Clue\React\Zenity\Launcher;
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Zen\BaseZen;
+use React\EventLoop\Factory;
 
-class LauncherTest extends TestCase
+class FunctionalLauncherTest extends TestCase
 {
     private $loop;
     private $dialog;
@@ -27,9 +28,9 @@ class LauncherTest extends TestCase
 
         $promise = $this->launcher->launch($this->dialog);
 
-        $this->loop->run();
+        $result = Block\await($promise, $this->loop, 1.0);
 
-        $promise->then($this->expectCallableOnceWith('--hello --world'));
+        $this->assertEquals('--hello --world', $result);
     }
 
     public function testDoesPassStdin()
@@ -44,9 +45,9 @@ class LauncherTest extends TestCase
             $zen->close();
         });
 
-        $this->loop->run();
+        $result = Block\await($zen->promise(), $this->loop, 1.0);
 
-        $zen->promise()->then($this->expectCallableOnceWith('okay'));
+        $this->assertEquals('okay', $result);
     }
 
     public function testWaitForOutput()

--- a/tests/Zen/BaseZenTest.php
+++ b/tests/Zen/BaseZenTest.php
@@ -22,6 +22,7 @@ abstract class BaseZenTest extends TestCase
         $this->process->stdin = $this->instream;
 
         $this->process->stdout = $this->getMock('React\Stream\ReadableStreamInterface');
+        $this->process->stderr = $this->getMock('React\Stream\ReadableStreamInterface');
     }
 
     public function testClosingZenTerminatesProcess()


### PR DESCRIPTION
This simplifies termination logic and avoids keeping pending (and
unused) streams to the child process.

This should also fix the failing (timeout) tests on Travis.