### PR TITLE
Travis tests on PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - hhvm # ignore errors, see below
 
 sudo: false


### PR DESCRIPTION
Travis CI now [supports tests on upcoming PHP 7.3](https://github.com/travis-ci/travis-ci/issues/9717#issuecomment-429564626)!